### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,41 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @GetMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @PostMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @DeleteMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  // Alterado por GFT AI Impact Bot: tornou username e body privados e adicionou métodos de acesso
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 009d2e849a4b5c7afd2300e7043c0d8c5e0dd0e4

**Descrição:** Este Pull Request implementa várias mudanças no arquivo `src/main/java/com/scalesec/vulnado/CommentsController.java`. As mudanças incluem a substituição de `@RequestMapping` por `@GetMapping`, `@PostMapping` e `@DeleteMapping` e a modificação dos métodos de acesso das variáveis `username` e `body` na classe `CommentRequest`.

**Sumario:**

- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modificado): 
   - Substituído `@RequestMapping` por `@GetMapping` para o método `comments`
   - Substituído `@RequestMapping` por `@PostMapping` para o método `createComment`
   - Substituído `@RequestMapping` por `@DeleteMapping` para o método `deleteComment`
   - A classe `CommentRequest` agora tem `username` e `body` como variáveis privadas e novos métodos de acesso foram adicionados

**Recomendações:** Recomenda-se que o revisor verifique se a substituição dos métodos de request está de acordo com a lógica do aplicativo e que a alteração na classe `CommentRequest` não afeta nenhuma outra parte do código que depende dela. Certifique-se de realizar testes adequados para confirmar que tudo ainda está funcionando como esperado.