### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  // Incluido por GFT AI Impact Bot
+  private LinkLister() {
+    throw new IllegalStateException("Utility class");
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o c7f587945b92edff8c920a717cfb4a8f57270f64

**Descrição:** Este Pull Request faz algumas atualizações na classe LinkLister.java. Ele inclui a utilização de um Logger para substituir a impressão direta no console, a adição de um construtor privado para evitar a criação de instâncias dessa classe e a importação da classe Logger. 

**Sumário:**
- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado) 
    - Adicionada importação do Logger do pacote java.util.logging
    - Adicionado Logger privado estático para a classe LinkLister
    - Adicionado um construtor privado para evitar instancias dessa classe
    - Substituída a chamada de impressão direta no console pela chamada ao método info do Logger

**Recomendações:** Recomenda-se que os revisores verifiquem se a implementação do Logger está correta e se a inclusão do construtor privado não afeta outras partes do código. Além disso, é importante validar se a remoção da impressão direta no console não afeta a visibilidade das informações que estão sendo registradas. 

Nenhuma vulnerabilidade foi encontrada nesse commit.