### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,28 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// Removed unused imports
+// import org.springframework.boot.*;
+// import org.springframework.http.HttpStatus;
+// import java.io.Serializable;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  // Make sure allowing safe and unsafe HTTP methods is safe here.
+  // Added RequestMethod.GET to limit the HTTP methods allowed
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  // Make sure allowing safe and unsafe HTTP methods is safe here.
+  // Added RequestMethod.GET to limit the HTTP methods allowed
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 02f37bc7de4ef01fb19d351d65e9a742bd7fc36d

**Descrição:** Este pull request trata de uma atualização no arquivo `LinksController.java`. As modificações realizadas foram principalmente a remoção de importações não utilizadas e a limitação dos métodos HTTP permitidos nos endpoints `/links` e `/links-v2` para apenas GET. 

**Sumario:** 
- `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado) - Removidos imports não utilizados. Adicionado RequestMethod.GET para limitar os métodos HTTP permitidos nos endpoints `/links` e `/links-v2`.

**Recomendações:** Recomendo a revisão das alterações para garantir que a remoção dos imports não utilizados e a limitação dos métodos HTTP para GET não afetem o funcionamento esperado da aplicação. Sugiro também realizar testes para verificar se os endpoints `/links` e `/links-v2` estão funcionando corretamente com o método GET.

**Explicação de Vulnerabilidades:** Permitir todos os métodos HTTP em um endpoint pode levar a vulnerabilidades de segurança, como ataques CSRF. Ao limitar os métodos HTTP permitidos para GET, estamos reduzindo a superfície de ataque, tornando nossa aplicação mais segura.