### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o feec4a908a9e1ea15b6322c59592bc17dff584ad
**Descrição:** Este Pull Request altera o arquivo src/main/java/com/scalesec/vulnado/LinkLister.java para incluir o Logger, substituir a saída do console pelo Logger, e adicionar um construtor privado para ocultar o público implícito.

**Sumario:**
- Arquivo src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)
   - Import do Logger foi adicionado.
   - LOGGER foi definido como um atributo estático da classe LinkLister.
   - Foi adicionado um construtor privado para ocultar o construtor público implícito.
   - A saída do console (System.out.println) foi substituída pelo LOGGER para registrar o host.
   
**Recomendações:** 
É recomendado testar as alterações em um ambiente de desenvolvimento primeiro para garantir que a substituição do System.out.println pelo Logger não cause nenhum efeito indesejado. Além disso, como o construtor público foi ocultado e um privado foi adicionado, é necessário garantir que todas as instâncias de LinkLister estão sendo criadas corretamente.

Por favor, note que a última linha do arquivo não tem uma nova linha no final. Isso pode causar problemas em algumas ferramentas que esperam uma nova linha no final de cada arquivo. É recomendado adicionar uma nova linha no final do arquivo. 

Não foram encontradas vulnerabilidades de segurança nas alterações feitas neste Pull Request.