### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,26 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// Removed unused imports
+// import org.springframework.boot.*;
+// import org.springframework.http.HttpStatus;
+// import java.io.Serializable;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  // Added method type to ensure only safe HTTP methods are allowed
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Altered by GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  // Added method type to ensure only safe HTTP methods are allowed
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Altered by GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o b050ac92cb24a6cb5533003d76150edf26eecba9
**Descrição:** Foram feitas alterações na classe `LinksController.java`, onde foram removidos imports não usados e adicionados métodos específicos para as rotas HTTP.

**Sumario:** 
- `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado) - Foram removidos os imports não utilizados do `springframework.boot.*`, `springframework.http.HttpStatus` e `java.io.Serializable`. Além disso, foram especificados os métodos HTTP nas rotas `@RequestMapping` para `/links` e `/links-v2`, garantindo que apenas métodos HTTP seguros sejam permitidos.

**Recomendações:** Recomendo que o revisor verifique se todos os imports removidos realmente não são necessários e se a restrição dos métodos HTTP para GET apenas não vai quebrar alguma funcionalidade existente. Além disso, é importante verificar se as rotas agora restritas ao método GET estão funcionando corretamente.

**Explicação de Vulnerabilidades:** Nesse caso, não foram encontradas vulnerabilidades. As alterações realizadas visam melhorar a qualidade do código, removendo partes não utilizadas e restringindo as rotas HTTP para aumentar a segurança.