### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LoginController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LoginController.java
+++ b/src/main/java/com/scalesec/vulnado/LoginController.java
@@ -1,10 +1,10 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
+// import org.springframework.boot.*; // Removido por GFT AI Impact Bot
+// import org.springframework.stereotype.*; // Removido por GFT AI Impact Bot
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
-import org.springframework.stereotype.*;
 import org.springframework.beans.factory.annotation.*;
 import java.io.Serializable;
 
@@ -14,11 +14,12 @@ public class LoginController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/login", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  // @CrossOrigin(origins = "*") // Alterado por GFT AI Impact Bot
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Incluido por GFT AI Impact Bot
+  @PostMapping(value = "/login", produces = "application/json", consumes = "application/json") // Alterado por GFT AI Impact Bot
   LoginResponse login(@RequestBody LoginRequest input) {
-    User user = User.fetch(input.username);
-    if (Postgres.md5(input.password).equals(user.hashedPassword)) {
+    User user = User.fetch(input.getUsername()); // Alterado por GFT AI Impact Bot
+    if (Postgres.md5(input.getPassword()).equals(user.hashedPassword())) { // Alterado por GFT AI Impact Bot
       return new LoginResponse(user.token(secret));
     } else {
       throw new Unauthorized("Access Denied");
@@ -27,13 +28,18 @@ public class LoginController {
 }
 
 class LoginRequest implements Serializable {
-  public String username;
-  public String password;
+  private String username; // Alterado por GFT AI Impact Bot
+  private String password; // Alterado por GFT AI Impact Bot
+
+  public String getUsername() { return username; } // Incluido por GFT AI Impact Bot
+  public String getPassword() { return password; } // Incluido por GFT AI Impact Bot
 }
 
 class LoginResponse implements Serializable {
-  public String token;
+  private static final String token; // Alterado por GFT AI Impact Bot
   public LoginResponse(String msg) { this.token = msg; }
+
+  public String getToken() { return token; } // Incluido por GFT AI Impact Bot
 }
 
 @ResponseStatus(HttpStatus.UNAUTHORIZED)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 794276b11e53c4cb9f335f58a7171e870757ec01

**Descrição:** Este Pull Request traz uma série de alterações no arquivo `LoginController.java`, que pertence ao pacote `com.scalesec.vulnado`. As alterações estão voltadas para a melhoria da segurança e da qualidade do código.

**Sumário:**
- `src/main/java/com/scalesec/vulnado/LoginController.java` (alterado):
  - Importações desnecessárias foram removidas.
  - O método de requisição foi alterado de `@RequestMapping` para `@PostMapping`.
  - A anotação `@CrossOrigin` teve seu valor de origem alterado de `"*"` para `"http://trustedwebsite.com"`.
  - Métodos `getter` foram adicionados para `username` e `password` na classe `LoginRequest`.
  - O modificador de acesso dos atributos `username`, `password` e `token` foi alterado de `public` para `private`.
  - Foi adicionado um método `getter` para `token` na classe `LoginResponse`.

**Recomendações:** É importante verificar se a nova origem definida na anotação `@CrossOrigin` é realmente confiável. Além disso, é bom garantir que a mudança dos modificadores de acesso e a adição dos métodos `getters` não quebrem outras partes do código que dependem desses atributos.

**Explicação de Vulnerabilidades:** Anteriormente, a anotação `@CrossOrigin` estava definida para permitir solicitações de qualquer origem (`"*"`), o que é uma prática insegura e pode levar a ataques Cross-Origin Resource Sharing (CORS). Agora, a anotação foi alterada para permitir solicitações apenas de um site confiável. Além disso, atributos `public` podem ser acessados e modificados diretamente, o que pode ser inseguro. Alterar os modificadores de acesso para `private` e adicionar métodos `getters` é uma prática de encapsulamento que aumenta a segurança do código.