### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,41 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @GetMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @PostMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @DeleteMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  // Alterado por GFT AI Impact Bot: tornou username e body privados e adicionou métodos de acesso
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o ee624d993179eb04f7fb613f6e691ca3b1695e0d
**Descrição:** Este Pull Request atualiza a classe CommentsController no arquivo src/main/java/com/scalesec/vulnado/CommentsController.java. As principais alterações envolvem a substituição das anotações @RequestMapping por anotações mais específicas como @GetMapping, @PostMapping e @DeleteMapping. Além disso, os atributos 'username' e 'body' da classe CommentRequest foram alterados para privados e foram adicionados métodos de acesso a esses atributos.

**Sumario:** 
- src/main/java/com/scalesec/vulnado/CommentsController.java (alterado)
    - Substituídas as anotações @RequestMapping pelos equivalentes mais específicos @GetMapping, @PostMapping e @DeleteMapping nas rotas de comentários.
    - Alterado o método de criação de comentários para usar os métodos de acesso getUsername() e getBody() da classe CommentRequest.
    - Alterada a classe CommentRequest para tornar 'username' e 'body' privados e adicionados métodos de acesso a esses atributos.

**Recomendações:** 
- Verifique se a alteração das anotações @RequestMapping para as anotações mais específicas não afeta a funcionalidade das rotas de comentários.
- Certifique-se de que a alteração dos atributos 'username' e 'body' para privados e a adição de métodos de acesso não quebrou a funcionalidade de criação de comentários.
- Teste todas as rotas de comentários para garantir que elas ainda estão funcionando como esperado após essas alterações.
