### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  // Incluido por GFT AI Impact Bot
+  private LinkLister() {
+    // Construtor privado para esconder o implícito público
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o f3157a220b7be14a224408c5ef874fee1973caca

**Descrição:** Este Pull Request faz algumas modificações no arquivo src/main/java/com/scalesec/vulnado/LinkLister.java, principalmente para melhorar a qualidade do código, tornando-o mais seguro e fácil de manter.

**Sumario:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)
  - Importação da biblioteca java.util.logging.Logger para permitir o registro de logs.
  - Adicionado um Logger privado e estático para a classe LinkLister.
  - Adicionado um construtor privado para a classe LinkLister para esconder o construtor público implícito.
  - Substituído o System.out.println(host) por LOGGER.info(host) para melhorar a eficiência do registro de logs.

**Recomendações:** 
Para o revisor, por favor, verifique se a implementação do Logger está correta e se a substituição do System.out.println pelo LOGGER.info não afetará a funcionalidade do código. Além disso, teste a classe para verificar se o log está sendo gerado corretamente.

**Explicação de Vulnerabilidades:** 
Nenhuma vulnerabilidade de segurança foi encontrada nesse commit.