### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,23 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// Removed unused imports
+// import org.springframework.boot.*;
+// import org.springframework.http.HttpStatus;
+// import java.io.Serializable;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot: Added method = RequestMethod.GET to ensure only safe HTTP methods are allowed
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot: Added method = RequestMethod.GET to ensure only safe HTTP methods are allowed
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 9469a4dcc2a81b02586a85f265c68d7bf1394489

**Descrição:** Este pull request inclui uma atualização no arquivo `LinksController.java`. As alterações incluem a remoção de importações não utilizadas e a adição de `method = RequestMethod.GET` nas anotações `@RequestMapping` para os métodos `links` e `linksV2`. Isso garante que apenas os métodos HTTP seguros são permitidos.

**Sumario:** 
- Arquivo `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado)
  - Importações não utilizadas foram removidas.
  - Adicionado `method = RequestMethod.GET` nas anotações `@RequestMapping` para os métodos `links` e `linksV2`.

**Recomendações:** Recomendo que o revisor confirme se todas as importações não utilizadas foram removidas corretamente e se a adição de `method = RequestMethod.GET` nas anotações `@RequestMapping` não afeta outras partes do código. Também sugiro verificar se os métodos HTTP não seguros estão agora efetivamente bloqueados.

