### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Postgres.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -8,8 +8,16 @@ import java.security.NoSuchAlgorithmException;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public class Postgres {
+
+    private static final Logger LOGGER = Logger.getLogger(Postgres.class.getName());
+
+    // Incluido por GFT AI Impact Bot
+    private Postgres() {
+        throw new IllegalStateException("Utility class");
+    }
 
     public static Connection connection() {
         try {
@@ -22,17 +30,15 @@ public class Postgres {
             return DriverManager.getConnection(url,
                     System.getenv("PGUSER"), System.getenv("PGPASSWORD"));
         } catch (Exception e) {
-            e.printStackTrace();
-            System.err.println(e.getClass().getName()+": "+e.getMessage());
+            LOGGER.severe(e.getClass().getName()+": "+e.getMessage());
             System.exit(1);
         }
         return null;
     }
     public static void setup(){
-        try {
-            System.out.println("Setting up Database...");
-            Connection c = connection();
-            Statement stmt = c.createStatement();
+        try (Connection c = connection();
+             Statement stmt = c.createStatement()) { // Alterado por GFT AI Impact Bot
+            LOGGER.info("Setting up Database..."); // Alterado por GFT AI Impact Bot
 
             // Create Schema
             stmt.executeUpdate("CREATE TABLE IF NOT EXISTS users(user_id VARCHAR (36) PRIMARY KEY, username VARCHAR (50) UNIQUE NOT NULL, password VARCHAR (50) NOT NULL, created_on TIMESTAMP NOT NULL, last_login TIMESTAMP)");
@@ -51,9 +57,8 @@ public class Postgres {
 
             insertComment("rick", "cool dog m8");
             insertComment("alice", "OMG so cute!");
-            c.close();
         } catch (Exception e) {
-            System.out.println(e);
+            LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
             System.exit(1);
         }
     }
@@ -89,29 +94,25 @@ public class Postgres {
 
     private static void insertUser(String username, String password) {
        String sql = "INSERT INTO users (user_id, username, password, created_on) VALUES (?, ?, ?, current_timestamp)";
-       PreparedStatement pStatement = null;
-       try {
-          pStatement = connection().prepareStatement(sql);
+       try (PreparedStatement pStatement = connection().prepareStatement(sql)) { // Alterado por GFT AI Impact Bot
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
           pStatement.setString(3, md5(password));
           pStatement.executeUpdate();
        } catch(Exception e) {
-         e.printStackTrace();
+         LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
        }
     }
 
     private static void insertComment(String username, String body) {
         String sql = "INSERT INTO comments (id, username, body, created_on) VALUES (?, ?, ?, current_timestamp)";
-        PreparedStatement pStatement = null;
-        try {
-            pStatement = connection().prepareStatement(sql);
+        try (PreparedStatement pStatement = connection().prepareStatement(sql)) { // Alterado por GFT AI Impact Bot
             pStatement.setString(1, UUID.randomUUID().toString());
             pStatement.setString(2, username);
             pStatement.setString(3, body);
             pStatement.executeUpdate();
         } catch(Exception e) {
-            e.printStackTrace();
+            LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
         }
     }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 18a11cb18a86a7b9739870c3191bf9ee31a62bf1

**Descrição:** Este Pull Request faz várias alterações no arquivo src/main/java/com/scalesec/vulnado/Postgres.java. A maioria das alterações envolve a substituição de impressões de stacktrace e saídas de erro padrão por registros de log, a adição de um construtor privado para a classe utilitária e a modificação do uso de recursos JDBC para tentar com recursos, que garante o fechamento adequado dos recursos.

**Sumario:** 
- src/main/java/com/scalesec/vulnado/Postgres.java (modificado) - As stacktraces foram substituídas por registros de log usando a classe Logger. Além disso, um construtor privado foi adicionado à classe Postgres para prevenir a instanciação indevida da classe. Além disso, o uso de recursos JDBC foi alterado para tentar com recursos, que garante que os recursos sejam fechados adequadamente após o uso.

**Recomendações:** Recomendo que o revisor verifique se a classe Logger está sendo usada corretamente e se todos os recursos JDBC estão sendo fechados corretamente. Além disso, o revisor deve verificar se o construtor privado foi adicionado corretamente e se impede a instanciação da classe. Também sugiro que o revisor teste a funcionalidade do código após as alterações para garantir que tudo ainda funcione como esperado.