### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,22 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// import org.springframework.boot.*; // Removido por GFT AI Impact Bot
+// import org.springframework.http.HttpStatus; // Removido por GFT AI Impact Bot
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
-import java.util.List;
-import java.io.Serializable;
+// import java.io.Serializable; // Removido por GFT AI Impact Bot
 import java.io.IOException;
+import java.util.List;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 6459139fb62a22f948d99a652641567b849922e9

**Descrição:** Este Pull Request é uma atualização do arquivo `LinksController.java`. Vários imports foram removidos e as rotas `"/links"` e `"/links-v2"` foram alteradas para especificar o método GET.

**Sumário:**

- `src/main/java/com/scalesec/vulnado/LinksController.java` (alterado)
  - As linhas de importação `org.springframework.boot.*` e `org.springframework.http.HttpStatus` foram comentadas.
  - A linha de importação `java.io.Serializable` foi comentada.
  - As rotas `"/links"` e `"/links-v2"` foram atualizadas para especificar explicitamente o método GET.
  
**Recomendações:** 
- É importante garantir que as mudanças nas rotas não quebrem funcionalidades existentes.
- Assegure-se de que os imports removidos não sejam necessários em outras partes do código.
- Verifique se há suficiente cobertura de testes para estas rotas.

**Explicação de Vulnerabilidades:** Não foram encontradas vulnerabilidades no código alterado.