### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,41 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @GetMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @PostMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @DeleteMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  // Alterado por GFT AI Impact Bot: tornou username e body privados e adicionou getters
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 362690d6448f2dc1403bf59115fa43f1c84cb03f

**Descrição:** Este Pull Request foi criado para atualizar a classe `CommentsController` na aplicação, com o objetivo de melhorar a legibilidade e a segurança do código. 

**Sumário:**
- src/main/java/com/scalesec/vulnado/CommentsController.java (modificado)
  - Substituição dos métodos `@RequestMapping` por `@GetMapping`, `@PostMapping` e `@DeleteMapping` correspondentes, tornando o mapeamento dos métodos HTTP mais explícito.
  - Alteração dos campos `username` e `body` da classe `CommentRequest` para privados e adição de métodos getters, melhorando o encapsulamento dos dados.

**Recomendações:** Recomendo que o revisor verifique as alterações e confirme se a legibilidade do código foi melhorada e se não houve mudanças indesejadas na funcionalidade. Sugiro também executar testes para confirmar se a funcionalidade original está intacta após as modificações.