### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o fd4abf8eb8a6d53d716d0a64855d2effb5598626

**Descrição:** Este Pull Request traz atualizações no arquivo 'LinkLister.java'. Foram feitas alterações para melhorar a qualidade do código e a manutenção do mesmo, incluindo a adição de um logger para substituir a impressão de sistema e a adição de um construtor privado para ocultar o construtor público implícito.

**Sumario:**
- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)
  - Importação da classe 'Logger' do pacote 'java.util.logging'.
  - Adição de uma constante 'LOGGER' para registrar informações.
  - Adição de um construtor privado para a classe 'LinkLister' para ocultar o construtor público implícito.
  - Substituição de 'System.out.println(host)' por 'LOGGER.info(host)' para registrar a informação de hospedagem.

**Recomendações:** Recomendo que o revisor verifique a correta implementação do 'Logger' e se a mudança de 'System.out.println' para 'LOGGER.info' não afeta a funcionalidade do código. Também é importante garantir que a adição do construtor privado não traz nenhum efeito colateral indesejado.