### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,22 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// import org.springframework.boot.*; // Removido por GFT AI Impact Bot
+// import org.springframework.http.HttpStatus; // Removido por GFT AI Impact Bot
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
-import java.util.List;
-import java.io.Serializable;
+// import java.io.Serializable; // Removido por GFT AI Impact Bot
 import java.io.IOException;
+import java.util.List;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o bfe49355fb7a37bb573508acbbaeaf8b0bff1836

**Descrição:** Este Pull Request faz várias mudanças no arquivo 'LinksController.java'. Alguns pacotes que foram importados foram comentados e removidos, e os métodos HTTP padrão para as rotas '/links' e '/links-v2' foram explicitamente definidos como GET.

**Sumário:**
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java (modificado)
  - O import da classe 'org.springframework.boot.*' foi removido.
  - O import da classe 'org.springframework.http.HttpStatus' foi removido.
  - O import da classe 'java.io.Serializable' foi removido.
  - O método HTTP para a rota '/links' foi explicitamente definido como GET.
  - O método HTTP para a rota '/links-v2' foi explicitamente definido como GET.

**Recomendações:** Para o revisor, é importante verificar se a remoção desses pacotes importados não afeta outras partes do código que possam estar usando-os. Além disso, verificar se a mudança dos métodos HTTP para GET nas rotas especificadas não afeta a funcionalidade esperada da aplicação.

Por fim, é importante garantir que os testes unitários e de integração sejam executados para confirmar que todas as funcionalidades continuam funcionando conforme esperado após essas alterações.