### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o cdb616e2a9352e936c22298d242022047425f8fd
                                               
**Descrição:** O Pull Request traz uma atualização no arquivo `src/main/java/com/scalesec/vulnado/LinkLister.java`. As mudanças incluem a inclusão de um Logger, um construtor privado na classe `LinkLister` e a substituição de `System.out.println(host);` por `LOGGER.info(host);`.

**Sumario:** 

- `src/main/java/com/scalesec/vulnado/LinkLister.java` (alterado) - O Logger foi importado e uma instância privada estática foi criada na classe. Isso ajuda a registrar informações sobre a atividade do sistema. Além disso, um construtor privado foi adicionado à classe `LinkLister` para ocultar o construtor público implícito. Finalmente, `System.out.println(host);` foi substituído por `LOGGER.info(host);` para registrar o host em vez de imprimi-lo no console.

**Recomendações:** As alterações parecem estar em ordem. No entanto, seria bom testar as mudanças em um ambiente de teste antes de mesclá-las com o branch principal. Especificamente, verificar se o Logger está funcionando como esperado e se o construtor privado não está causando nenhum problema inesperado.

Por favor, note que a última linha do arquivo não tem uma nova linha no final do arquivo. Embora isso não cause um problema funcional, é uma prática recomendada terminar arquivos com uma nova linha.