### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,24 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
+// Removed unused imports
+// import org.springframework.boot.*;
+// import org.springframework.http.HttpStatus;
+// import java.io.Serializable;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 89f4a9fd1f7922a1f582428ac5a7d6614acd3c56
                                                
**Descrição:** As alterações realizadas no arquivo `src/main/java/com/scalesec/vulnado/LinksController.java` envolvem a remoção de importações não utilizadas, além da modificação de métodos de mapeamento de solicitação (`@RequestMapping`). As alterações foram realizadas para otimizar o código e melhorar a legibilidade.

**Sumário:**
- src/main/java/com/scalesec/vulnado/LinksController.java (modificado) 
  - Removido importações não utilizadas de `org.springframework.boot.*;`, `org.springframework.http.HttpStatus;` e `java.io.Serializable;`
  - Adicionado especificação do método GET no `@RequestMapping` para os métodos `links` e `linksV2`

**Recomendações:** Recomendo realizar testes para garantir que as alterações no mapeamento de solicitação não afetaram o comportamento esperado dos métodos `links` e `linksV2`. 

Seu report será salvo em Markdown, então deixe sua resposta no formato Markdown.