### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 412b58c1e52d3f6cef8e286d77e456b3dc8310a0
**Descrição:** Este Pull Request faz alterações na classe LinkLister. Foi adicionado um Logger para registrar informações ao invés de imprimi-las no console e um construtor privado foi inserido para ocultar o construtor público implícito. Além disso, foi feita uma troca de um System.out.println por um logger.info.

**Sumario:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)
    - Adicionada importação para o Logger do java.util.logging
    - Inserido um Logger privado estático para a classe LinkLister
    - Adicionado um construtor privado para ocultar o construtor público implícito
    - Substituído um System.out.println por um logger.info para registrar o host

**Recomendações:** 
- Verificar se o logger está funcionando corretamente e registrando as informações como esperado
- Confirmar se o construtor privado não está gerando efeitos colaterais indesejados na classe
- Garantir que a troca do System.out.println pelo logger.info não causou problemas na lógica do método getLinksV2
- Realizar testes unitários para confirmar o comportamento esperado após as alterações.