### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Postgres.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -8,8 +8,16 @@ import java.security.NoSuchAlgorithmException;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.UUID;
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
+import java.security.SecureRandom; // Incluido por GFT AI Impact Bot
 
 public class Postgres {
+
+    private static final Logger LOGGER = Logger.getLogger(Postgres.class.getName()); // Incluido por GFT AI Impact Bot
+
+    private Postgres() { // Incluido por GFT AI Impact Bot
+        // Construtor privado para esconder o público implícito
+    }
 
     public static Connection connection() {
         try {
@@ -22,17 +30,17 @@ public class Postgres {
             return DriverManager.getConnection(url,
                     System.getenv("PGUSER"), System.getenv("PGPASSWORD"));
         } catch (Exception e) {
-            e.printStackTrace();
-            System.err.println(e.getClass().getName()+": "+e.getMessage());
+            LOGGER.severe(e.getClass().getName()+": "+e.getMessage()); // Alterado por GFT AI Impact Bot
             System.exit(1);
         }
         return null;
     }
+
     public static void setup(){
-        try {
-            System.out.println("Setting up Database...");
-            Connection c = connection();
-            Statement stmt = c.createStatement();
+        try (Connection c = connection(); // Alterado por GFT AI Impact Bot
+             Statement stmt = c.createStatement()) { // Alterado por GFT AI Impact Bot
+
+            LOGGER.info("Setting up Database..."); // Alterado por GFT AI Impact Bot
 
             // Create Schema
             stmt.executeUpdate("CREATE TABLE IF NOT EXISTS users(user_id VARCHAR (36) PRIMARY KEY, username VARCHAR (50) UNIQUE NOT NULL, password VARCHAR (50) NOT NULL, created_on TIMESTAMP NOT NULL, last_login TIMESTAMP)");
@@ -51,20 +59,19 @@ public class Postgres {
 
             insertComment("rick", "cool dog m8");
             insertComment("alice", "OMG so cute!");
-            c.close();
         } catch (Exception e) {
-            System.out.println(e);
+            LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
             System.exit(1);
         }
     }
 
-    // Java program to calculate MD5 hash value
-    public static String md5(String input)
+    // Java program to calculate SHA-256 hash value
+    public static String sha256(String input) // Alterado por GFT AI Impact Bot
     {
         try {
 
-            // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
+            // Static getInstance method is called with hashing SHA-256
+            MessageDigest md = MessageDigest.getInstance("SHA-256"); // Alterado por GFT AI Impact Bot
 
             // digest() method is called to calculate message digest
             //  of an input digest() return array of byte
@@ -89,29 +96,25 @@ public class Postgres {
 
     private static void insertUser(String username, String password) {
        String sql = "INSERT INTO users (user_id, username, password, created_on) VALUES (?, ?, ?, current_timestamp)";
-       PreparedStatement pStatement = null;
-       try {
-          pStatement = connection().prepareStatement(sql);
+       try (PreparedStatement pStatement = connection().prepareStatement(sql)) { // Alterado por GFT AI Impact Bot
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
-          pStatement.setString(3, md5(password));
+          pStatement.setString(3, sha256(password)); // Alterado por GFT AI Impact Bot
           pStatement.executeUpdate();
        } catch(Exception e) {
-         e.printStackTrace();
+         LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
        }
     }
 
     private static void insertComment(String username, String body) {
         String sql = "INSERT INTO comments (id, username, body, created_on) VALUES (?, ?, ?, current_timestamp)";
-        PreparedStatement pStatement = null;
-        try {
-            pStatement = connection().prepareStatement(sql);
+        try (PreparedStatement pStatement = connection().prepareStatement(sql)) { // Alterado por GFT AI Impact Bot
             pStatement.setString(1, UUID.randomUUID().toString());
             pStatement.setString(2, username);
             pStatement.setString(3, body);
             pStatement.executeUpdate();
         } catch(Exception e) {
-            e.printStackTrace();
+            LOGGER.severe(e.getMessage()); // Alterado por GFT AI Impact Bot
         }
     }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 94f88f2548d06dfdc7c1718bb5ce0a3507d5162c
**Descrição:** Este Pull Request inclui uma série de melhorias de código na classe `Postgres.java`. As melhorias incluem a introdução do Logger para gerenciamento de exceções, mudança no método de hash de senha de MD5 para SHA-256, introdução do construtor privado, e uso do try-with-resources para gerenciamento automático de recursos.

**Sumário:**
- src/main/java/com/scalesec/vulnado/Postgres.java (modificado)
  - Incluído Logger para gerenciamento de exceções.
  - Incluído construtor privado para esconder o público implícito.
  - Alterado o método de hash de senha de MD5 para SHA-256, aumentando a segurança.
  - Usado o try-with-resources em blocos try para gerenciamento automático de recursos, melhorando a legibilidade e evitando possíveis vazamentos de recursos.

**Recomendações:** 
- Certifique-se de que todos os testes unitários e de integração passem após essas alterações.
- Verifique se o logging está funcionando corretamente e se as mensagens de log são úteis para a depuração.
- Verifique a implementação do SHA-256 para garantir que a hash da senha esteja sendo calculada corretamente.
- Certifique-se de que as conexões de banco de dados estão sendo fechadas corretamente com o uso de try-with-resources.

**Explicação de Vulnerabilidades:** 
- O uso anterior do MD5 para hash de senha é considerado inseguro, pois o MD5 é vulnerável a ataques de colisão. Isso foi corrigido mudando para o SHA-256.
- O manejo inadequado das exceções foi corrigido ao introduzir o Logger, proporcionando um melhor rastreamento dos erros.
- O uso anterior de blocos try sem a cláusula finally para fechar recursos pode levar a vazamentos de recursos. Isso foi corrigido com a introdução do try-with-resources.