### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,18 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName());
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +20,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +44,31 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.severe(e.getMessage());
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection()) {
+      LOGGER.info("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1";
+      stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      LOGGER.info(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");
         String password = rs.getString("password");
         user = new User(user_id, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+      LOGGER.severe(e.getClass().getName()+": "+e.getMessage());
     }
+    return user;
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o c7a57bc47b8585443c614d48e90547fc7b144a65

**Descrição:** Este Pull Request contém melhorias no código do arquivo User.java. As mudanças principais incluem a substituição de `java.sql.Statement` por `java.sql.PreparedStatement` para evitar problemas de segurança como SQL Injection, além de alterações de variáveis de `public` para `private` para seguir as boas práticas de encapsulamento em Java. Também foram adicionados métodos getters para essas variáveis. Outro ponto importante é a substituição de `e.printStackTrace();` por um logger, que é uma maneira mais eficiente e segura de lidar com exceções.

**Sumário:** 
- src/main/java/com/scalesec/vulnado/User.java (modificado) - As variáveis `id`, `username` e `hashedPassword` foram alteradas de `public` para `private` e foram adicionados métodos getters para elas. `java.sql.Statement` foi substituído por `java.sql.PreparedStatement` para prevenir SQL Injection. Foi adicionado um logger para lidar com exceções de maneira mais adequada.

**Recomendações:** Recomendo que o revisor verifique se todas as variáveis que foram alteradas para `private` não estão sendo acessadas diretamente em outra parte do código, pois isso pode gerar erros. Além disso, é importante garantir que o novo logger está funcionando corretamente e que todas as exceções estão sendo devidamente registradas. 

**Explicação de Vulnerabilidades:** A vulnerabilidade de SQL Injection, que poderia ocorrer ao usar `java.sql.Statement`, foi mitigada com a substituição por `java.sql.PreparedStatement`, que permite a utilização de parâmetros e evita que comandos SQL sejam injetados no código. Além disso, a prática de imprimir a stack trace de exceções (`e.printStackTrace()`) pode expor informações sensíveis sobre a aplicação, por isso foi substituída por um logger.