### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,9 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // Private constructor to hide the implicit public one.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
     List<String> result = new ArrayList<String>();
     Document doc = Jsoup.connect(url).get();
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o eb6cc6167adb4927efd168658713be2fcbbb3fb5

**Descrição:** Este Pull Request inclui uma atualização no arquivo src/main/java/com/scalesec/vulnado/LinkLister.java. As alterações introduzem algumas melhorias de código, incluindo a adição de um Logger para registro de logs e a substituição de uma impressão de console por um log de informação. Além disso, um construtor privado foi adicionado à classe LinkLister para esconder o construtor público implícito.

**Sumário:**
- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado) - Adicionado Logger para registro de logs e substituído a impressão do console por um log de informação. Adicionado um construtor privado para esconder o construtor público implícito.

**Recomendações:** Recomendo que o revisor verifique a implementação do Logger e confirme se a remoção da impressão do console e a substituição por um log de informação não afetam a funcionalidade do código. Além disso, o revisor deve verificar se o novo construtor privado não afeta de maneira adversa a maneira como a classe LinkLister é usada em outros lugares do código.